### PR TITLE
Fix warning about jinja2 templates in when

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,5 +22,5 @@
 - name: confirm saxon is working
   command: "java -cp {{ saxon_dir }}/saxon9he.jar net.sf.saxon.Query -t -qs:'current-date()'"
   register: saxon_test
-  failed_when: "'{{ saxon_version }}' not in saxon_test.stderr"
+  failed_when: "saxon_version not in saxon_test.stderr"
   changed_when: false


### PR DESCRIPTION
When running this play I'm seeing the following warning:

```
TASK [saxon : confirm saxon is working] ****************************************************************************************
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: '{{ saxon_version
}}' not in saxon_test.stderr
```

This fixes the warning.